### PR TITLE
Gcc binary support

### DIFF
--- a/examples/count_up_down-1.c
+++ b/examples/count_up_down-1.c
@@ -27,7 +27,7 @@ uint64_t main() {
 
   read(0, n, 8); 
 
-  x = n;
+  x = *n;
   y = 0;
 
   while(x > 0) {

--- a/examples/main-return-1.c
+++ b/examples/main-return-1.c
@@ -1,0 +1,3 @@
+uint64_t main() {
+  return 42;
+}

--- a/examples/main-return-2.c
+++ b/examples/main-return-2.c
@@ -1,0 +1,7 @@
+uint64_t main() {
+  int x;
+
+  x = 42;
+
+  return x;
+}

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -910,6 +910,10 @@ fn exec_ecall(state: &mut EmulatorState) {
         syscall_openat(state);
     } else if a7_value == SyscallId::Brk as u64 {
         syscall_brk(state);
+    } else if a7_value == SyscallId::Close as u64 {
+        // TODO close system call
+    } else if a7_value == SyscallId::Newfstat as u64 {
+        // TODO newfstat system call
     } else {
         warn!("unknown system call: {}", a7_value);
         state.set_reg(Register::A0, u64::MAX);

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -273,11 +273,13 @@ fn execute(state: &mut EmulatorState, instr: Instruction) {
         Instruction::Mul(rtype) => exec_mul(state, rtype),
         Instruction::Div(rtype) => exec_div(state, rtype),
         Instruction::Divu(rtype) => exec_divu(state, rtype),
+        Instruction::Rem(rtype) => exec_rem(state, rtype),
         Instruction::Remu(rtype) => exec_remu(state, rtype),
         Instruction::Addw(rtype) => exec_addw(state, rtype),
         Instruction::Subw(rtype) => exec_subw(state, rtype),
         Instruction::Sllw(rtype) => exec_sllw(state, rtype),
         Instruction::Mulw(rtype) => exec_mulw(state, rtype),
+        Instruction::Divw(rtype) => exec_divw(state, rtype),
         Instruction::Ecall(_itype) => exec_ecall(state),
         // TODO: Cover all needed instructions here.
         _ => unimplemented!("not implemented: {:?}", instr),
@@ -803,14 +805,26 @@ fn exec_mulw(state: &mut EmulatorState, rtype: RType) {
     state.pc_next();
 }
 
-// rd = rs1 /s rs2
+// rd = rs1 / rs2
 // pc = pc + 4
 fn exec_div(state: &mut EmulatorState, rtype: RType) {
     let rs1_value = state.get_reg(rtype.rs1());
     let rs2_value = state.get_reg(rtype.rs2());
     assert!(rs2_value != 0, "check for non-zero divisor");
     let rd_value = (rs1_value as i64).wrapping_div(rs2_value as i64) as u64;
-    trace_rtype(state, "divu", rtype, rd_value);
+    trace_rtype(state, "div", rtype, rd_value);
+    state.set_reg(rtype.rd(), rd_value);
+    state.pc_next();
+}
+
+// rd = s64(rs1{32} / rs2{32})
+// pc = pc + 4
+fn exec_divw(state: &mut EmulatorState, rtype: RType) {
+    let rs1_value = state.get_reg(rtype.rs1());
+    let rs2_value = state.get_reg(rtype.rs2());
+    assert!(rs2_value != 0, "check for non-zero divisor");
+    let rd_value = (rs1_value as i32).wrapping_div(rs2_value as i32) as u64;
+    trace_rtype(state, "divw", rtype, rd_value);
     state.set_reg(rtype.rd(), rd_value);
     state.pc_next();
 }
@@ -823,6 +837,18 @@ fn exec_divu(state: &mut EmulatorState, rtype: RType) {
     assert!(rs2_value != 0, "check for non-zero divisor");
     let rd_value = rs1_value.wrapping_div(rs2_value);
     trace_rtype(state, "divu", rtype, rd_value);
+    state.set_reg(rtype.rd(), rd_value);
+    state.pc_next();
+}
+
+// rd = rs1 % rs2
+// pc = pc + 4
+fn exec_rem(state: &mut EmulatorState, rtype: RType) {
+    let rs1_value = state.get_reg(rtype.rs1());
+    let rs2_value = state.get_reg(rtype.rs2());
+    assert!(rs2_value != 0, "check for non-zero divisor");
+    let rd_value = (rs1_value  as i64).wrapping_rem(rs2_value  as i64)  as u64;
+    trace_rtype(state, "rem", rtype, rd_value);
     state.set_reg(rtype.rd(), rd_value);
     state.pc_next();
 }

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -908,6 +908,12 @@ fn exec_ecall(state: &mut EmulatorState) {
         syscall_openat(state);
     } else if a7_value == SyscallId::Brk as u64 {
         syscall_brk(state);
+    } else if a7_value == SyscallId::Close as u64 {
+        // TODO close system call
+    } else if a7_value == SyscallId::Lseek as u64 {
+        // TODO lseek system call
+    } else if a7_value == SyscallId::Newfstat as u64 {
+        // TODO newfstat system call
     } else {
         warn!("unknown system call: {}", a7_value);
         state.set_reg(Register::A0, u64::MAX);

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -904,8 +904,8 @@ fn exec_ecall(state: &mut EmulatorState) {
         syscall_read(state);
     } else if a7_value == SyscallId::Write as u64 {
         syscall_write(state);
-	} else if a7_value == SyscallId::Open as u64 {
-		syscall_open(state);
+    } else if a7_value == SyscallId::Open as u64 {
+        syscall_open(state);
     } else if a7_value == SyscallId::Openat as u64 {
         syscall_openat(state);
     } else if a7_value == SyscallId::Brk as u64 {

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -908,12 +908,6 @@ fn exec_ecall(state: &mut EmulatorState) {
         syscall_openat(state);
     } else if a7_value == SyscallId::Brk as u64 {
         syscall_brk(state);
-    } else if a7_value == SyscallId::Close as u64 {
-        // TODO close system call
-    } else if a7_value == SyscallId::Lseek as u64 {
-        // TODO lseek system call
-    } else if a7_value == SyscallId::Newfstat as u64 {
-        // TODO newfstat system call
     } else {
         warn!("unknown system call: {}", a7_value);
         state.set_reg(Register::A0, u64::MAX);

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -904,6 +904,8 @@ fn exec_ecall(state: &mut EmulatorState) {
         syscall_read(state);
     } else if a7_value == SyscallId::Write as u64 {
         syscall_write(state);
+	} else if a7_value == SyscallId::Open as u64 {
+		syscall_open(state);
     } else if a7_value == SyscallId::Openat as u64 {
         syscall_openat(state);
     } else if a7_value == SyscallId::Brk as u64 {
@@ -970,6 +972,26 @@ fn syscall_write(state: &mut EmulatorState) {
 
     state.set_reg(Register::A0, result);
     debug!("write({},{:#x},{}) -> {}", fd, buffer, size, result);
+}
+
+fn syscall_open(state: &mut EmulatorState) {
+    let path = state.get_reg(Register::A0);
+    let flag = state.get_reg(Register::A1);
+    let mode = state.get_reg(Register::A2);
+    let temp = state.get_reg(Register::A3);
+
+    // TODO Set fd to AT_FDCWD
+    // state.set_reg(Register::A0, AT_FDCWD);
+    state.set_reg(Register::A1, path);
+    state.set_reg(Register::A2, flag);
+    state.set_reg(Register::A3, mode);
+
+    syscall_openat(state);
+
+    // needed?
+    state.set_reg(Register::A1, flag);
+    state.set_reg(Register::A2, mode);
+    state.set_reg(Register::A3, temp);
 }
 
 fn syscall_openat(state: &mut EmulatorState) {

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -265,6 +265,7 @@ fn execute(state: &mut EmulatorState, instr: Instruction) {
         Instruction::Add(rtype) => exec_add(state, rtype),
         Instruction::Sub(rtype) => exec_sub(state, rtype),
         Instruction::Sll(rtype) => exec_sll(state, rtype),
+        Instruction::Slt(rtype) => exec_slt(state, rtype),
         Instruction::Sltu(rtype) => exec_sltu(state, rtype),
         Instruction::Srl(rtype) => exec_srl(state, rtype),
         Instruction::Sra(rtype) => exec_sra(state, rtype),
@@ -744,6 +745,19 @@ fn exec_sra(state: &mut EmulatorState, rtype: RType) {
     let rs2_value = state.get_reg(rtype.rs2());
     let rd_value = (rs1_value as i64).wrapping_shr(rs2_value as u32) as u64;
     trace_rtype(state, "sra", rtype, rd_value);
+    state.set_reg(rtype.rd(), rd_value);
+    state.pc_next();
+}
+
+// rd = 1                     ||| if (rs1 < rs2)
+// rd = 0                     ||| otherwise
+// pc = pc + 4
+fn exec_slt(state: &mut EmulatorState, rtype: RType) {
+    let rs1_value = state.get_reg(rtype.rs1());
+    let rs2_value = state.get_reg(rtype.rs2());
+    let condition = (rs1_value as i64) < (rs2_value as i64);
+    let rd_value = EmulatorValue::from(condition);
+    trace_rtype(state, "slt", rtype, rd_value);
     state.set_reg(rtype.rd(), rd_value);
     state.pc_next();
 }

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -281,6 +281,7 @@ fn execute(state: &mut EmulatorState, instr: Instruction) {
         Instruction::Sllw(rtype) => exec_sllw(state, rtype),
         Instruction::Mulw(rtype) => exec_mulw(state, rtype),
         Instruction::Divw(rtype) => exec_divw(state, rtype),
+        Instruction::Remw(rtype) => exec_remw(state, rtype),
         Instruction::Ecall(_itype) => exec_ecall(state),
         // TODO: Cover all needed instructions here.
         _ => unimplemented!("not implemented: {:?}", instr),
@@ -863,6 +864,18 @@ fn exec_rem(state: &mut EmulatorState, rtype: RType) {
     assert!(rs2_value != 0, "check for non-zero divisor");
     let rd_value = (rs1_value  as i64).wrapping_rem(rs2_value  as i64)  as u64;
     trace_rtype(state, "rem", rtype, rd_value);
+    state.set_reg(rtype.rd(), rd_value);
+    state.pc_next();
+}
+
+// rd = s64(rs1{32} % rs2{32})
+// pc = pc + 4
+fn exec_remw(state: &mut EmulatorState, rtype: RType) {
+    let rs1_value = state.get_reg(rtype.rs1());
+    let rs2_value = state.get_reg(rtype.rs2());
+    assert!(rs2_value != 0, "check for non-zero divisor");
+    let rd_value = (rs1_value  as i32).wrapping_rem(rs2_value  as i32)  as u64;
+    trace_rtype(state, "remw", rtype, rd_value);
     state.set_reg(rtype.rd(), rd_value);
     state.pc_next();
 }

--- a/src/engine/system.rs
+++ b/src/engine/system.rs
@@ -10,6 +10,9 @@ pub enum SyscallId {
     Write = 64,
     Openat = 56,
     Brk = 214,
+    Close = 57,
+    Lseek = 62,
+    Newfstat = 80
 }
 
 // Prepares arguments on the stack like a UNIX system. Note that we

--- a/src/engine/system.rs
+++ b/src/engine/system.rs
@@ -11,6 +11,8 @@ pub enum SyscallId {
     Open = 1024,
     Openat = 56,
     Brk = 214,
+    Close = 57,
+    Newfstat = 80
 }
 
 // Prepares arguments on the stack like a UNIX system. Note that we

--- a/src/engine/system.rs
+++ b/src/engine/system.rs
@@ -10,9 +10,6 @@ pub enum SyscallId {
     Write = 64,
     Openat = 56,
     Brk = 214,
-    Close = 57,
-    Lseek = 62,
-    Newfstat = 80
 }
 
 // Prepares arguments on the stack like a UNIX system. Note that we

--- a/src/engine/system.rs
+++ b/src/engine/system.rs
@@ -8,6 +8,7 @@ pub enum SyscallId {
     Exit = 93,
     Read = 63,
     Write = 64,
+    Open = 1024,
     Openat = 56,
     Brk = 214,
     Close = 57,


### PR DESCRIPTION
- [x] Add remaining instructions (Rem, Div, Remw, Divw etc.)
- [x] Support read() systemcall
- [x] All read() examples work on unicorn emulator (excluding open())
- [x] Support write() systemcall
- [x] All write() examples work on unicorn emulator (excluding open())
- [x] Support open() systemcall
- [x] All open() examples work on unicorn emulator
- [x] Selfie works on unicorn emulator